### PR TITLE
Provide dispatch as a dependency for the useElmish hook 

### DIFF
--- a/App.fs
+++ b/App.fs
@@ -60,7 +60,7 @@ module private Components =
         let theme = Mui.useTheme ()
 
         let (someText, setSomeText) = React.useState props.text
-        let state, dispatch = React.useElmish(TextField.init, TextField.update props.dispatch)
+        let state, dispatch = React.useElmish(TextField.init, TextField.update props.dispatch, [| box props.dispatch |])
 
         let applySetText s =
             s |> TextField.Update |> dispatch


### PR DESCRIPTION
When using any `props` as part of the Elmish program definition, whether inside `init` or `update`, they have to be provided as _dependencies_ array of the `useElmish` hook. Fixes #2 